### PR TITLE
Load PC/SC library soname on Linux

### DIFF
--- a/deno-pcsc-ffi/pcsc-ffi-wrapper.ts
+++ b/deno-pcsc-ffi/pcsc-ffi-wrapper.ts
@@ -17,7 +17,7 @@ import { FFI_SCARDREADERSTATE } from './reader.ts';
 
 const libPath = {
   "windows": "winscard.dll",
-  "linux": "libpcsclite.so",
+  "linux": "libpcsclite.so.1",
   "darwin": "/System/Library/Frameworks/PCSC.framework/PCSC",
 };
 


### PR DESCRIPTION
On GNU/Linux the PC/SC library soname is "libpcsclite.so.1", not just "libpcsclite.so" which is the name used by the linker.

For example if the Debian package libpcsclite-dev is NOT installed we have the runtime error:
error: Uncaught Error: Could not open library: Could not open library: libpcsclite.so: cannot open shared object file: No such file or directory const libPCSC = Deno.dlopen(
                     ^
    at new DynamicLibrary (deno:ext/ffi/00_ffi.js:274:39)
    at Object.dlopen (deno:ext/ffi/00_ffi.js:368:12)
    at file:///.../pcsc-deno/deno-pcsc-ffi/pcsc-ffi-wrapper.ts:30:22